### PR TITLE
Cache FX and ORDER constants

### DIFF
--- a/src/engine/steps/applyEffects.js
+++ b/src/engine/steps/applyEffects.js
@@ -8,21 +8,21 @@ import soilEffects      from '@/engine/effects/soil.js'
 import topographyEffects from '@/engine/effects/topography.js'
 import weatherEffects   from '@/engine/effects/weather.js'
 
+export const FX = {
+    animals:    animalEffects,
+    assemblies: assemblyEffects,
+    plants:     plantEffects,
+    resources:  resourceEffects,
+    soil:       soilEffects,
+    topography: topographyEffects,
+    weather:    weatherEffects
+}
+
+// execution order
+export const ORDER = ['weather','assemblies','topography','soil','animals','plants','resources']
+
 export function applyEffects () {
     const map = mapStore()
-
-    const FX = {
-        animals:    animalEffects,
-        assemblies: assemblyEffects,
-        plants:     plantEffects,
-        resources:  resourceEffects,
-        soil:       soilEffects,
-        topography: topographyEffects,
-        weather:    weatherEffects
-    }
-
-    // execution order
-    const ORDER = ['weather','assemblies','topography','soil','animals','plants','resources']
 
     ////console.log('[applyEffects] start')
 


### PR DESCRIPTION
## Summary
- export FX and ORDER at module scope so effects data is cached on load
- applyEffects now uses shared FX and ORDER constants

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(No files matching the pattern "tests" were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b849bfec83278d9891e804dab328