### PR TITLE
Preserve assemblies across effect application

### DIFF
--- a/src/engine/steps/applyEffects.js
+++ b/src/engine/steps/applyEffects.js
@@ -197,6 +197,7 @@ function runApplyEffectsSingleThread(tiles2D) {
                 resources:  { ...tile.resources },
                 plants:     (tile.plants  || []).map(p => ({ ...p })),
                 animals:    (tile.animals || []).map(a => ({ ...a })),
+                assemblies: Array.isArray(tile.assemblies) ? tile.assemblies.map(a => ({...a, orders: Array.isArray(a.orders) ? [...a.orders] : []})) : [],
             }
 
             const bumpGroup = (groupName, prop, delta) => {

--- a/src/engine/workers/effectWorkers.js
+++ b/src/engine/workers/effectWorkers.js
@@ -59,6 +59,7 @@ function applyEffectsToTile(tile) {
         resources:  { ...tile.resources },
         plants:     (tile.plants  || []).map(p => ({ ...p })),
         animals:    (tile.animals || []).map(a => ({ ...a })),
+        assemblies: Array.isArray(tile.assemblies) ? tile.assemblies.map(a => ({...a, orders: Array.isArray(a.orders) ? [...a.orders] : []})) : [],
     }
 
     const bumpGroup = (groupName, prop, delta) => {


### PR DESCRIPTION
## Summary
- ensure effect worker copies assemblies and nested orders before mutation
- mirror assembly copying in single-threaded fallback

## Testing
- `npm run lint` *(fails: No files matching pattern "tests"; numerous lint errors)*
- `npm test` *(fails: No test files found)*
- `npm run dev` *(server starts at http://localhost:5173)*

------
https://chatgpt.com/codex/tasks/task_e_68abb1efa4888327963f794c69747183