### PR TITLE
refactor: centralize overlay styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -31,6 +31,32 @@
   padding-right: 0.5em;
 }
 
+/* Overlay panel styles */
+.panel {
+  border: 1px solid white;
+  margin: 0;
+  background: black;
+}
+
+.panel-header {
+  font-weight: bold;
+  padding: 4px;
+  cursor: pointer;
+}
+
+.panel-body {
+  padding: 4px;
+}
+
+.panel .controlButton {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: bold;
+  border-top: 1px solid white;
+  padding: 4px;
+}
+
 .card {
   background: black;
   border-radius: var(--radius);

--- a/src/components/overlays/News.vue
+++ b/src/components/overlays/News.vue
@@ -18,7 +18,5 @@ const collapsed = toRef(props, 'collapsed')
 
 
 <style scoped>
-.panel { border: 1px solid white; margin: 0; }
-.panel-header { font-weight: bold; padding: 4px; cursor: pointer; }
-.controlButton { display: flex; justify-content: center; align-items: center; font-weight: bold; border-top: 1px solid #000; padding: 4px; }
+.controlButton { border-top: 1px solid #000; }
 </style>

--- a/src/components/overlays/Weather.vue
+++ b/src/components/overlays/Weather.vue
@@ -46,10 +46,6 @@ Humidity: ${humidityPct.value}%`
 </template>
 
 <style scoped>
-.panel { border: 1px solid white; margin: 0;   background: black;}
-.panel-header { font-weight: bold; padding: 4px; cursor: pointer; }
-.panel-body { padding: 4px; }
-.controlButton { display: flex; justify-content: center; align-items: center; font-weight: bold; border-top: 1px solid white; padding: 4px; }
 .metrics { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 4px; margin-top: 6px; }
 .metrics div { border-top: 1px solid white; padding: 4px; }
 </style>


### PR DESCRIPTION
## Summary
- centralize shared overlay panel styles in `main.css`
- clean up `Weather` and `News` overlays to use global panel styles

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac4f331de88327b4d6ebda5c651cd1