### PR TITLE
refactor: centralize overlay styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -33,9 +33,12 @@
 
 /* Overlay panel styles */
 .panel {
-  border: 1px solid white;
+  background: #0f1418;
+  color: #e0e0e0;
+  border: 1px solid var(--color-primary);
+  border-radius: 10px;
+  padding: 0.8rem;
   margin: 0;
-  background: black;
 }
 
 .panel-header {
@@ -53,9 +56,51 @@
   justify-content: center;
   align-items: center;
   font-weight: bold;
-  border-top: 1px solid white;
+  border-top: 1px solid var(--color-primary);
   padding: 4px;
 }
+
+/* Key-value table styles */
+.kv {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 12.5px;
+  background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(0,0,0,.2));
+  border: 1px solid var(--panel-edge, #2a3b45);
+  margin: 8px 0;
+  color: var(--text, #e0e0e0);
+}
+
+.kv th,
+.kv td {
+  border: 1px solid color-mix(in oklab, var(--panel-edge, #2a3b45), #000 25%);
+  padding: 6px 8px;
+  white-space: nowrap;
+  text-align: left;
+  vertical-align: top;
+}
+
+.kv.compact th,
+.kv.compact td { padding: 5px 7px; }
+
+.kv th {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--text-dim, #a9b4bd);
+  background: linear-gradient(180deg, #151a20, #10151b);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.kv tbody tr:nth-child(odd) td { background-color: rgba(255,255,255,.015); }
+.kv tbody tr:hover td { background-color: color-mix(in oklab, var(--accent, #7df9ff), transparent 95%); }
+
+.kv.inner { border: 0; background: transparent; }
+.kv.inner td { border: 0; padding: 2px 0; }
+.kv.inner.onecol td { white-space: normal; }
 
 .card {
   background: black;
@@ -64,6 +109,7 @@
   padding: 0.7em 0.8em;
   display: flex;
   flex-direction: column;
+  border: 1px solid #2a3b45;
 }
 
 .card--horizontal {

--- a/src/components/overlays/AnalyticsReport.vue
+++ b/src/components/overlays/AnalyticsReport.vue
@@ -11,9 +11,9 @@ The sections are :
 <script setup>
 import {computed, ref, defineComponent} from 'vue'
 import {gameStore} from '@/stores/game.js'
-import expandableTable from "@/components/overlays/AnalyticsReportBlocks/ExpandableTable.vue";
-import simpleTable from "@/components/overlays/AnalyticsReportBlocks/SimpleTable.vue";
-import weatherDays from "@/components/overlays/AnalyticsReportBlocks/WeatherDays.vue";
+import expandableTable from '@/components/overlays/AnalyticsReportBlocks/ExpandableTable.vue';
+import simpleTable from '@/components/overlays/AnalyticsReportBlocks/SimpleTable.vue';
+import weatherDays from '@/components/overlays/AnalyticsReportBlocks/WeatherDays.vue';
 
 const game = gameStore()
 
@@ -236,47 +236,6 @@ const subcomponents = {
   padding: 10px 12px 12px;
   max-height: 1200px; /* plenty; body height is unknown */
 }
-
-/* ---------- Tables (shared across subcomponents) ---------- */
-:deep(.kv) {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-  font-size: 12.5px;
-  background: linear-gradient(180deg, rgba(255,255,255,.02), rgba(0,0,0,.2));
-  border: 1px solid var(--panel-edge);
-  margin: 8px 0;
-  color: var(--text);
-}
-:deep(.kv th), :deep(.kv td) {
-  border: 1px solid color-mix(in oklab, var(--panel-edge), #000 25%);
-  padding: 6px 8px;
-  white-space: nowrap;
-  text-align: left;
-  vertical-align: top;
-}
-:deep(.kv.compact th), :deep(.kv.compact td) { padding: 5px 7px; }
-:deep(.kv th) {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: .06em;
-  color: var(--text-dim);
-  background: linear-gradient(180deg, #151a20, #10151b);
-  position: sticky; /* helpful when tables overflow vertically */
-  top: 0;
-  z-index: 1;
-}
-:deep(.kv tbody tr:nth-child(odd) td) {
-  background-color: rgba(255,255,255,.015);
-}
-:deep(.kv tbody tr:hover td) {
-  background-color: rgba(125, 249, 255, .05);
-}
-
-/* inner one-column tables in expandable cells */
-:deep(.kv.inner) { border: 0; background: transparent; }
-:deep(.kv.inner td) { border: 0; padding: 2px 0; }
-:deep(.kv.inner.onecol td) { white-space: normal; }
 
 /* Chips / tokens */
 :deep(.token) {

--- a/src/components/overlays/AnimalsMenu.vue
+++ b/src/components/overlays/AnimalsMenu.vue
@@ -2,10 +2,8 @@
 //TODO => Make sure the measuring assemblies set up an expiry date for the
 </script>
 <template>
-  <div class="animalMenu">Animals Menu</div>
+  <div class="panel animalMenu">Animals Menu</div>
 
 </template>
 
-<style scoped>
-.animalMenu{display: block; background: green;}
-</style>
+

--- a/src/components/overlays/EventLog.vue
+++ b/src/components/overlays/EventLog.vue
@@ -8,8 +8,8 @@ const events = gameStore()
 </script>
 
 <template>
-  <div class="logModal">
-    <table>
+  <div class="panel logModal">
+    <table class="kv">
       <thead>
       <tr>
         <th>Engine</th>
@@ -26,14 +26,7 @@ const events = gameStore()
 </template>
 
 <style scoped>
-.logModal {
-
-  background: black;
-  color: white;
-  bottom: 0;
-  overflow: auto;
-
-}
+.logModal { overflow: auto; }
 
 .operations {
   color: purple;

--- a/src/components/overlays/FarmGate.vue
+++ b/src/components/overlays/FarmGate.vue
@@ -2,13 +2,9 @@
 
 </script>
 <template>
-  <div class="farmGate"> Farm Gate</div>
+  <div class="panel farmGate"> Farm Gate</div>
 
 </template>
 
-<style scoped>
-.farmGate {
-  background: orangered;
-}
-</style>
+
 

--- a/src/components/overlays/Market.vue
+++ b/src/components/overlays/Market.vue
@@ -55,7 +55,7 @@ const fmtDate = s => s ? new Date(s).toLocaleDateString() : ''
       <div class="grid">
         <div class="card">
           <h4>Inputs & Utilities</h4>
-          <table>
+          <table class="kv">
             <thead>
             <tr>
               <th>Item</th>
@@ -75,7 +75,7 @@ const fmtDate = s => s ? new Date(s).toLocaleDateString() : ''
 
         <div class="card">
           <h4>Plants (seed, seedling/sapling)</h4>
-          <table>
+          <table class="kv">
             <thead>
             <tr>
               <th>Type</th>
@@ -95,7 +95,7 @@ const fmtDate = s => s ? new Date(s).toLocaleDateString() : ''
 
         <div class="card">
           <h4>Animals (by stage)</h4>
-          <table>
+          <table class="kv">
             <thead>
             <tr>
               <th>Type</th>
@@ -206,35 +206,10 @@ const fmtDate = s => s ? new Date(s).toLocaleDateString() : ''
   align-items: center;
 }
 
-.panel {
-  background: #0f1418;
-  color: #e0e0e0;
-  border: 1px solid #00bcd4;
-  border-radius: 10px;
-  padding: .8rem;
-}
-
 .grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: .8rem;
-}
-
-.card {
-  border: 1px solid #2a3b45;
-  border-radius: 8px;
-  padding: .6rem;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th, td {
-  border-bottom: 1px solid #2a3b45;
-  padding: .35rem .4rem;
-  text-align: left;
 }
 
 .list {

--- a/src/components/overlays/News.vue
+++ b/src/components/overlays/News.vue
@@ -17,6 +17,4 @@ const collapsed = toRef(props, 'collapsed')
 </template>
 
 
-<style scoped>
-.controlButton { border-top: 1px solid #000; }
-</style>
+

--- a/src/components/overlays/PlantsMenu.vue
+++ b/src/components/overlays/PlantsMenu.vue
@@ -3,13 +3,7 @@
 </script>
 
 <template>
-  <div class="plantsMenu"> Plants Menu</div>
+  <div class="panel plantsMenu"> Plants Menu</div>
 
 </template>
 
-
-<style scoped>
-.plantsMenu{
-  background: royalblue;
-}
-</style>

--- a/src/components/overlays/ResourcesMenu.vue
+++ b/src/components/overlays/ResourcesMenu.vue
@@ -3,12 +3,8 @@
 </script>
 
 <template>
-  <div class="resourcesMenu"> Resources Menu    Water, Electricity, Fertilizer and Feed
+  <div class="panel resourcesMenu"> Resources Menu    Water, Electricity, Fertilizer and Feed
   </div>
 </template>
 
-<style scoped>
-.resourcesMenu {
-  background: mediumvioletred;
-}
-</style>
+

--- a/src/components/overlays/TileInfo.vue
+++ b/src/components/overlays/TileInfo.vue
@@ -121,7 +121,7 @@ function fmt(entry) {
 </script>
 
 <template>
-  <div class="modalData" v-if="currentTile">
+  <div class="panel modalData" v-if="currentTile">
     <div class="headerRow">
       <h4>Tile {{ selectedKey }}</h4>
       <button class="close" @click="map.selectedTile.value = null">Close</button>
@@ -149,13 +149,11 @@ function fmt(entry) {
 
     <div v-else>No comparable values on this tile.</div>
   </div>
-  <div v-else class="modalData">No tile selected.</div>
+  <div v-else class="panel modalData">No tile selected.</div>
 </template>
 
 <style scoped>
-.modalData { background: black; max-height: 70vh; overflow: auto; padding: 8px; }
-.kv { width: 100%; border-collapse: collapse; font-size: 13px; }
-.kv th, .kv td { border: 1px solid #ccc; padding: 4px 6px; white-space: nowrap; text-align: left; }
+.modalData { max-height: 70vh; overflow: auto; padding: 8px; }
 .changed { background: rgba(255, 235, 59, 0.25); }
 .up td:last-child { color: #2e7d32; font-weight: 600; }
 .down td:last-child { color: #c62828; font-weight: 600; }


### PR DESCRIPTION
## Summary
- centralize panel, card, and key-value table styling in main.css
- switch overlays to shared classes and remove redundant scoped CSS

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Custom elements in iteration require 'v-bind:key')*


------
https://chatgpt.com/codex/tasks/task_e_68ae5b846738832781e294882a715c54