### PR TITLE
refactor: centralize shared panel styles

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -49,7 +49,48 @@
 
 .panel-body {
   padding: 4px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
+
+.panel--fill {
+  display: block;
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  max-height: none;
+  overflow: auto;
+  padding: 8px;
+  box-sizing: border-box;
+}
+
+.panel-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+.panel-header-row h4 { margin: 0; }
+
+.groups-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  grid-auto-flow: row;
+  grid-auto-rows: min-content;
+  align-items: start;
+  align-content: start;
+}
+
+.group-section {
+  align-self: start;
+  min-height: 0;
+}
+
+.group-title { margin: 0 0 6px 0; }
+
+.noToggle .table-header .linklike { display: none !important; }
 
 .panel .controlButton {
   display: flex;
@@ -80,6 +121,16 @@
   text-align: left;
   vertical-align: top;
 }
+
+.kv-wrap th,
+.kv-wrap td {
+  white-space: normal;
+  word-break: break-word;
+}
+
+.changed { background: rgba(255, 235, 59, 0.25); }
+.up td:last-child { color: #2e7d32; font-weight: 600; }
+.down td:last-child { color: #c62828; font-weight: 600; }
 
 .kv.compact th,
 .kv.compact td { padding: 5px 7px; }

--- a/src/components/grid/TileInfo.vue
+++ b/src/components/grid/TileInfo.vue
@@ -124,15 +124,15 @@ function fmt(entry) {
 </script>
 
 <template>
-  <div class="panel modalData" v-if="currentTile">
-    <div class="headerRow">
+  <div class="panel panel--fill" v-if="currentTile">
+    <div class="panel-header-row">
       <h4>Tile {{ selectedKey }}</h4>
     </div>
 
-    <div v-if="grouped.length" class="groupsGrid">
-      <section v-for="g in grouped" :key="g.group" class="groupSection">
-        <h5 class="groupTitle">{{ g.group.toUpperCase() }}</h5>
-        <table class="kv">
+    <div v-if="grouped.length" class="groups-grid">
+      <section v-for="g in grouped" :key="g.group" class="group-section">
+        <h5 class="group-title">{{ g.group.toUpperCase() }}</h5>
+        <table class="kv kv-wrap">
           <thead>
           <tr>
             <th>Path</th>
@@ -157,59 +157,5 @@ function fmt(entry) {
     <div v-else>No comparable values on this tile.</div>
   </div>
 
-  <div v-else class="panel modalData">No tile selected.</div>
+  <div v-else class="panel panel--fill">No tile selected.</div>
 </template>
-
-<style scoped>
-.modalData {
-  display: block;
-  width: 100%;
-  max-width: none;
-  height: 100%;
-  max-height: none;
-  overflow: auto;
-  padding: 8px;
-  box-sizing: border-box;
-}
-
-.headerRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 8px;
-}
-.headerRow h4 { margin: 0; }
-
-.groupsGrid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  grid-auto-flow: row;
-  grid-auto-rows: min-content; /* rows sized to their content */
-  align-items: start;          /* items top-aligned inside cells */
-  align-content: start;        /* grid packed at the top */
-}
-
-.groupSection {
-  align-self: start;
-  min-height: 0;               /* prevent accidental stretch */
-}
-
-
-.groupTitle {
-  margin: 0 0 6px 0;          /* remove default top margin */
-}
-
-.kv {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0;
-  table-layout: fixed;         /* avoid intrinsic table width pushing */
-}
-
-.kv th, .kv td { padding: 4px 6px; border-bottom: 1px solid rgba(0,0,0,.2); word-break: break-word; }
-.changed { background: rgba(255, 235, 59, 0.25); }
-.up td:last-child { color: #2e7d32; font-weight: 600; }
-.down td:last-child { color: #c62828; font-weight: 600; }
-</style>

--- a/src/components/overlays/EventLog.vue
+++ b/src/components/overlays/EventLog.vue
@@ -8,7 +8,7 @@ const events = gameStore()
 </script>
 
 <template>
-  <div class="panel logModal">
+  <div class="panel panel--fill">
     <table class="kv">
       <thead>
       <tr>
@@ -26,8 +26,6 @@ const events = gameStore()
 </template>
 
 <style scoped>
-.logModal { overflow: auto; }
-
 .operations {
   color: purple;
 }

--- a/src/components/overlays/News.vue
+++ b/src/components/overlays/News.vue
@@ -68,9 +68,5 @@ const totalRows = computed(() =>
 </template>
 
 <style scoped>
-/* vertical scroll only */
-.panel-body { overflow-y: auto; overflow-x: hidden; }
-/* hide collapsers inside reused blocks for this overlay */
-:deep(.noToggle .table-header .linklike) { display: none !important; }
 .emptyHint { opacity: .7; font-size: 12px; margin-top: 6px; }
 </style>

--- a/src/components/overlays/Weather.vue
+++ b/src/components/overlays/Weather.vue
@@ -79,10 +79,4 @@ const forecastDays = computed(() => game.analyticsReport?.weather?.forecast || [
 
 <style scoped>
 .controlsRow { display: flex; gap: 6px; margin-bottom: 8px; }
-
-/* keep vertical scroll only; no horizontal */
-.panel-body { overflow-y: auto; overflow-x: hidden; }
-
-/* hide collapsers inside reused blocks for this overlay */
-:deep(.noToggle .table-header .linklike) { display: none !important; }
 </style>


### PR DESCRIPTION
## Summary
- centralize modal/panel utility classes in main.css, including scroll handling and table formatting
- slim TileInfo and overlay components to use shared classes
- remove redundant per-component styles

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Custom elements in iteration require 'v-bind:key' directives)*

------
https://chatgpt.com/codex/tasks/task_e_68afa5d744648327b633f68e8f6cbad6