### PR TITLE
Use SimpleTable in Market overlay

### DIFF
--- a/src/components/overlays/AnalyticsReport.vue
+++ b/src/components/overlays/AnalyticsReport.vue
@@ -147,6 +147,7 @@ const subcomponents = {
       <div class="sectionBody">
         <component
             v-for="(subsection) in section.subcomponents"
+            :key="subsection.type + '-' + (subsection.title || '')"
             :is="subcomponents[subsection.type]"
             :data="subsection.data"
             :title="subsection.title"


### PR DESCRIPTION
## Summary
- Replace card-based Price Catalog with reusable SimpleTable blocks
- Compute table data for inputs, plants, and animals
- Add missing v-for key in AnalyticsReport to satisfy lint

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6e9ed7c8327a255e3b40f444b17