### PR TITLE
refactor: use SimpleTable for event log

### DIFF
--- a/src/components/overlays/EventLog.vue
+++ b/src/components/overlays/EventLog.vue
@@ -1,27 +1,30 @@
 <script setup>
-import {gameStore} from '/src/stores/game.js';
-
+import { computed } from 'vue'
+import {gameStore} from '/src/stores/game.js'
+import simpleTable from '@/components/overlays/blocks/SimpleTable.vue'
 
 const events = gameStore()
 
+const headers = ['Engine', 'Message']
+
+const rows = computed(() =>
+    (events.log || []).map(ev => ({
+      className: ev.engine,
+      cells: [ev.engine, ev.msg]
+    }))
+)
 
 </script>
 
 <template>
   <div class="panel panel--fill">
-    <table class="kv">
-      <thead>
-      <tr>
-        <th>Engine</th>
-        <th>Message</th>
-      </tr>
-      </thead>
-      <tr v-for="event in events.log" :class="event.engine">
-        <td> {{ event.engine }}</td>
-        <td> {{ event.msg }}</td>
-      </tr>
-    </table>
-
+    <simpleTable
+        title="Event Log"
+        :headers="headers"
+        :data="rows"
+        :startOpen="true"
+        class="noToggle"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- extend SimpleTable to accept row objects with classes
- swap EventLog's ad-hoc table for SimpleTable and pass log entries

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f40890083278519546f64fa0403