### PR TITLE
refactor: centralize date and value formatting

### DIFF
--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -3,6 +3,7 @@ import {reactive, computed, onMounted, onBeforeUnmount, watch, ref} from 'vue'
 import eventBus from '@/eventBus.js'
 import {gameStore} from '@/stores/game.js'
 import {clearSavedStores, loadAllStores} from '@/utils/persistance.js'
+import { formatDateLocale, formatDateTime } from '@/utils/formatting.js'
 
 const game = gameStore()
 const phase = computed(() => game.phase)
@@ -129,7 +130,7 @@ function syncMeasuredToEnvOnce() {
   const addOneDayISO = () => {
     const d = new Date(game.currentDate)
     d.setDate(d.getDate() + 1)
-    return d.toISOString()
+    return formatDateTime(d)
   }
   const stamp = addOneDayISO()
 
@@ -348,10 +349,10 @@ onBeforeUnmount(stopTestingSync)
       <div class="subpanel">
         <div class="infoScreen" title="Gold">Operator:<br/>{{ userAvatar }} {{ userName }} <br/>💰{{ gold }}</div>
         <div class="infoScreen">Stage: <br/> {{ stageLabel?.toUpperCase() }}</div>
-        <div class="infoScreen">Date:<br/>{{
-            game.currentDate.toLocaleDateString('en-GB')
-          }}<br/>Turn:{{ game.currentTurn }}
-        </div>
+          <div class="infoScreen">Date:<br/>{{
+              formatDateLocale(game.currentDate)
+            }}<br/>Turn:{{ game.currentTurn }}
+          </div>
         <div class="infoScreen">Phase:<br/>{{ currentPhaseLabel?.toUpperCase() }}</div>
 
 

--- a/src/components/overlays/Market.vue
+++ b/src/components/overlays/Market.vue
@@ -3,9 +3,14 @@ import { computed } from 'vue'
 import { gameStore } from '@/stores/game.js'
 import { marketStore } from '@/stores/market.js'
 import simpleTable from '@/components/overlays/blocks/SimpleTable.vue'
+import { formatDateLocale, formatMoney, formatNumber } from '@/utils/formatting.js'
 
 const game = gameStore()
 const market = marketStore()
+
+const fmtMoney = n => formatMoney(n)
+const fmtNum = n => formatNumber(n)
+const fmtDate = d => formatDateLocale(d)
 
 // Group contracts
 const offeredContracts = computed(() =>
@@ -64,21 +69,13 @@ const animalsRows = computed(() => {
   return rows
 })
 
-const today = computed(() => {
-  const d = game.currentDate
-  return d ? new Date(d).toISOString().slice(0, 10) : ''
-})
-
-const fmtMoney = n => typeof n === 'number' ? `${Math.round(n)}💰` : '—'
-const fmtNum = n => typeof n === 'number' ? Math.round(n) : '—'
-const fmtDate = s => s ? new Date(s).toLocaleDateString() : ''
 </script>
 <template>
   <div class="market-overlay">
     <header class="bar">
       <div><strong>Market</strong></div>
-      <div>Gold: <strong>{{ Math.round(game.gold) }}</strong></div>
-      <div>Today: {{ fmtDate(today) }}</div>
+      <div>Gold: <strong>{{ fmtNum(game.gold) }}</strong></div>
+      <div>Today: {{ fmtDate(game.currentDate) }}</div>
       <div>Last flux: {{ fmtDate(market.lastMarketDate) }}</div>
     </header>
 

--- a/src/engine/phases/analytics/buildResourceUse.js
+++ b/src/engine/phases/analytics/buildResourceUse.js
@@ -1,5 +1,6 @@
 // UI-ready builder for the “Resource use” section
 import eventBus from '@/eventBus.js'
+import { formatNumber } from '@/utils/formatting.js'
 
 /**
  * Sum current (measured) vs optimized resource values across the grid.
@@ -11,7 +12,7 @@ import eventBus from '@/eventBus.js'
 export function buildResourceUse(currentGrid2D, currentDateISO) {
   eventBus.emit('log', { engine: 'analytics', msg: 'Building Resource Use Report' })
 
-  const fmt = (n) => (Number.isFinite(n) ? n.toFixed(2) : '—')
+    const fmt = (n) => formatNumber(n, 2)
 
   // totals[key] = { unit, curr:number|null, proj:number|null }
   const totals = Object.create(null)

--- a/src/engine/phases/analytics/produceReport.js
+++ b/src/engine/phases/analytics/produceReport.js
@@ -7,14 +7,13 @@ import { buildMarket } from './buildMarket.js'
 import { buildEcology } from './buildEcology.js'
 import { buildTileDiff } from './buildTileDiff.js'
 import { buildResourceUse } from './buildResourceUse.js'
-
-const iso = (d) => new Date(d).toISOString().slice(0, 10)
+import { formatDate } from '@/utils/formatting.js'
 
 export function produceReport() {
     const game = gameStore()
     const map = mapStore()
 
-    const currentDateISO = iso(game.currentDate || Date.now())
+    const currentDateISO = formatDate(game.currentDate || Date.now())
     const currentGrid2D = Array.isArray(map.tiles) ? map.tiles : (map.tiles?.value || [])
     const previousGrid2D = Array.isArray(map.previousDayTiles) ? map.previousDayTiles : (map.previousDayTiles?.value || [])
 

--- a/src/engine/simulationUpdate/marketFlux.js
+++ b/src/engine/simulationUpdate/marketFlux.js
@@ -4,9 +4,10 @@ import {gameStore} from '@/stores/game.js'
 import {marketStore} from '@/stores/market.js'
 import {plantStore} from '@/stores/plant.js'
 import {animalStore} from '@/stores/animal.js'
+import { formatDate } from '@/utils/formatting.js'
 
 // ——— utils
-const iso = d => new Date(d).toISOString().slice(0, 10)
+const iso = formatDate
 const rint = (a, b) => Math.floor(Math.random() * (b - a + 1)) + a
 const pick = arr => arr[Math.floor(Math.random() * arr.length)]
 

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,5 +1,6 @@
 import {defineStore} from 'pinia'
 import {computed, ref, watch} from 'vue'
+import { formatDate } from '@/utils/formatting.js'
 
 export const gameStore = defineStore('gameStore', () => {
     const gold = ref(300000)
@@ -29,7 +30,7 @@ export const gameStore = defineStore('gameStore', () => {
         }
     ])
     const stageChangeCalendar = [];
-    const startDate = ref(new Date().toISOString().slice(0, 10))
+    const startDate = ref(formatDate(new Date()))
     const currentTurn = ref(0)
     const currentDate = computed(() => {
         const d = new Date(startDate.value);

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -1,21 +1,50 @@
-function formatDate(iso) {
-    if (!iso) return '—'
-    try {
-        const d = new Date(iso)
-        if (Number.isNaN(d.getTime())) return String(iso)
-        return d.toISOString().slice(0, 10)
-    } catch {
-        return String(iso)
-    }
-}
-function formatValue(entry) {
-    if (!entry) return 'No entry'
-    const { value, unit } = entry
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return `${value.toFixed(2)}${unit ? ' ' + unit : ''}`
-    }
-    if (value == null) return 'No data'
-    return `${String(value)}${unit ? ' ' + unit : ''}`
+function formatDate(d) {
+  if (!d) return ''
+  try {
+    const date = new Date(d)
+    if (Number.isNaN(date.getTime())) return String(d)
+    return date.toISOString().slice(0, 10)
+  } catch {
+    return String(d)
+  }
 }
 
-export {formatDate, formatValue}
+function formatDateLocale(d, locale = 'en-GB') {
+  if (!d) return ''
+  try {
+    return new Date(d).toLocaleDateString(locale)
+  } catch {
+    return ''
+  }
+}
+
+function formatDateTime(d) {
+  if (!d) return ''
+  try {
+    return new Date(d).toISOString()
+  } catch {
+    return ''
+  }
+}
+
+function formatNumber(n, digits = 0) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—'
+  return digits > 0 ? Number(n).toFixed(digits) : String(Math.round(n))
+}
+
+function formatMoney(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return '—'
+  return `${Math.round(n)}💰`
+}
+
+function formatValue(entry) {
+  if (!entry) return 'No entry'
+  const { value, unit } = entry
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `${value.toFixed(2)}${unit ? ' ' + unit : ''}`
+  }
+  if (value == null) return 'No data'
+  return `${String(value)}${unit ? ' ' + unit : ''}`
+}
+
+export { formatDate, formatDateLocale, formatDateTime, formatNumber, formatMoney, formatValue }


### PR DESCRIPTION
## Summary
- consolidate date and numeric formatting helpers in `utils/formatting`
- refactor stores, engine, and overlays to reuse shared formatting

## Testing
- `npm test` *(fails: No test files found)*
- `npx eslint src --ext .js,.vue` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b51637d4832788b3eed86d416615