### PR TITLE
feat: add assemblies menu overlay

### DIFF
--- a/src/components/overlays/AssembliesMenu.vue
+++ b/src/components/overlays/AssembliesMenu.vue
@@ -1,16 +1,124 @@
 <script setup>
-//TODO => Clear all actions that are not marked as recurring.
-//TODO => Make sure the measuring assemblies set up an expiry date for the measurements
+import { computed } from 'vue'
+import { mapStore } from '@/stores/map.js'
+import { gameStore } from '@/stores/game.js'
+import { actionRequirements } from '@/dict/actionRequirements.js'
+
+const map = mapStore()
+const game = gameStore()
+
+const currentTile = computed(() => {
+  const selected = map.selectedTile
+  return selected && typeof selected === 'object' && 'value' in selected ? selected.value : selected
+})
+
+function addActionToTile(category, action) {
+  const tile = currentTile.value
+  if (!tile) return
+  tile.assemblies.optimized.push({ category, action })
+}
 </script>
 
 <template>
-  <div class="assembliesMenu">
- Assemblies Menu
+  <div class="panel assembliesMenu">
+    <div class="panel-header-row">
+      <h4>Assemblies</h4>
+    </div>
+
+    <div v-if="!currentTile" class="hint">Select a tile to plan assembly actions.</div>
+
+    <div v-else class="menu-body">
+      <div class="assemblies-list">
+        <div
+          v-for="assembly in game.stationAssemblies"
+          :key="assembly.id"
+          class="card"
+        >
+          <div class="card-header">
+            <div class="card-title">{{ assembly.name }}</div>
+          </div>
+          <div class="card-body">
+            <div>Built: {{ assembly.built ? 'Yes' : 'No' }}</div>
+            <div>Deployed: {{ assembly.deployed ? 'Yes' : 'No' }}</div>
+            <div>Moves: {{ assembly.moves }}</div>
+            <div>Actions: {{ assembly.actions }}</div>
+            <div class="modules">
+              <div v-for="(m, i) in assembly.modules" :key="i">
+                {{ m.type }}<span v-if="m.subtype">: {{ m.subtype }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="actions-list">
+        <div
+          v-for="(actions, category) in actionRequirements"
+          :key="category"
+          class="action-area"
+        >
+          <h4>{{ category }}</h4>
+          <button
+            v-for="actionName in Object.keys(actions)"
+            :key="actionName"
+            :disabled="!currentTile"
+            @click="addActionToTile(category, actionName)"
+          >
+            {{ actionName }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .assembliesMenu {
-  background: blueviolet;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.menu-body {
+  display: flex;
+  gap: 12px;
+  height: 100%;
+}
+
+.assemblies-list,
+.actions-list {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+}
+
+.card {
+  border: 1px solid var(--border, #2c3e50);
+  border-radius: 10px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-title {
+  font-weight: 600;
+}
+
+.modules {
+  margin-top: 4px;
+}
+
+.hint {
+  opacity: 0.8;
 }
 </style>


### PR DESCRIPTION
## Summary
- implement assemblies overlay with station assemblies list
- add action categories with buttons to queue assembly actions on tiles

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: Parsing error and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fdda15e48327a6a4d1528e0e7efd