### PR TITLE
style: centralize decorative styles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -51,7 +51,6 @@ html, body, #app {
   margin: 0;
   height: 100%;
   overflow: hidden;
-  background: black;
 }
 
 main {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,8 +1,12 @@
+
+html, body, #app {
+  background: black;
+}
+
 #app {
   margin: 0 auto;
   font-weight: normal;
   color:white;
-  background: orange;
 }
 
 :root {
@@ -169,6 +173,10 @@
   color: yellow;;
 }
 
+.text-bold {
+  font-weight: bold;
+}
+
 .btn {
   border: none;
   border-radius: var(--radius);
@@ -210,6 +218,20 @@
 .btn--new:hover {
   background: #ffb300;
   color: #333;
+}
+
+.btn--start {
+  background: #82c91e;
+  color: #fff;
+}
+
+.btn--start:disabled {
+  background: grey;
+  cursor: not-allowed;
+}
+
+.btn--start:hover {
+  background: #5c940d;
 }
 
 .btn--close {

--- a/src/components/StartingScreen.vue
+++ b/src/components/StartingScreen.vue
@@ -79,12 +79,12 @@ async function startGame() {
     <h2>Agrobots' LandOS Simulator</h2>
   <form @submit.prevent="startGame" class="start-form" v-if="!resuming && !terrainGeneration">
     <div>
-      <label for="userName">Your Name:</label>
+      <label for="userName" class="text-bold">Your Name:</label>
       <input id="userName" type="text" v-model="name" autocomplete="off" autofocus/>
     </div>
 
     <div>
-      <label for="userAvatar">Choose Your Avatar:</label>
+      <label for="userAvatar" class="text-bold">Choose Your Avatar:</label>
       <select id="userAvatar" v-model="avatar">
         <option v-for="option in avatarOptions" :key="option.emoji" :value="option.emoji" :title="option.label">
           {{ option.emoji }}
@@ -93,9 +93,9 @@ async function startGame() {
     </div>
 
     <div>
-      <label>Difficulty:</label>
+      <label class="text-bold">Difficulty:</label>
       <div class="difficulty-options">
-        <label v-for="option in difficultyOptions" :key="option.value">
+        <label v-for="option in difficultyOptions" :key="option.value" class="text-bold">
           <input
               type="radio"
               name="difficulty"
@@ -107,7 +107,7 @@ async function startGame() {
         </label>
       </div>
     </div>
-    <button type="submit" class="btn start-btn" :disabled="!name">Start</button>
+    <button type="submit" class="btn btn--start start-btn" :disabled="!name">Start</button>
   </form>
   <div v-if="resuming" class="terrain-overlay">Loading save…</div>
   <div v-else-if="terrainGeneration" class="terrain-overlay">Generating terrain…</div>
@@ -123,10 +123,6 @@ async function startGame() {
   gap: 1.2rem;
 }
 
-.start-form label {
-  font-weight: bold;
-}
-
 .difficulty-options {
   display: flex;
   gap: 1.2rem;
@@ -136,17 +132,10 @@ async function startGame() {
   margin-top: 1rem;
   font-size: 1.1em;
   padding: 0.5em 1.2em;
-  background: #82c91e;
-  color: #fff;
 }
 
 .start-btn:disabled {
-  background: grey;
   cursor: not-allowed;
-}
-
-.start-btn:hover {
-  background: #5c940d;
 }
 
 h1 ,h2 {text-align: center;}

--- a/src/engine/simulationUpdate/applyEffects.js
+++ b/src/engine/simulationUpdate/applyEffects.js
@@ -12,7 +12,7 @@ import soilEffects from '@/engine/effects/soilEffects.js'
 import topographyEffects from '@/engine/effects/topographyEffects.js'
 import weatherEffects from '@/engine/effects/weatherEffects.js'
 
-import {roundN} from "@/utils/formatting.js";
+import {roundN} from '@/utils/formatting.js';
 
 const MAX_WORKERS = Math.min(4, navigator.hardwareConcurrency || 4)
 
@@ -81,6 +81,7 @@ export async function applyEffects() {
             try {
                 w.terminate()
             } catch {
+                // ignore termination errors
             }
         })
     }


### PR DESCRIPTION
## Summary
- Move root background styling to global main.css
- Extract StartingScreen button and label aesthetics into reusable classes
- Documented worker termination errors to satisfy lint

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc3db43c8327bc98024cb6042904