### PR TITLE
feat: add theme switching

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,15 +1,27 @@
 
 html, body, #app {
-  background: black;
+  background: var(--app-bg);
 }
 
 #app {
   margin: 0 auto;
   font-weight: normal;
-  color:white;
+  color: var(--app-text);
 }
 
-:root {
+:root[data-theme="light"] {
+  --app-bg: white;
+  --app-text: black;
+  --color-primary: #1976d2;
+  --color-accent: #90caf9;
+  --color-warning: #ffb300;
+  --color-dark: #333;
+  --radius: 7px;
+}
+
+:root[data-theme="dark"] {
+  --app-bg: black;
+  --app-text: white;
   --color-primary: #00bcd4;
   --color-accent: #cde4cf;
   --color-warning: #ffd600;

--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -4,6 +4,7 @@ import eventBus from '@/eventBus.js'
 import {gameStore} from '@/stores/game.js'
 import {clearSavedStores, loadAllStores} from '@/utils/persistance.js'
 import { formatDateLocale, formatDateTime } from '@/utils/formatting.js'
+import { themeStore } from '@/stores/theme.js'
 
 const game = gameStore()
 const phase = computed(() => game.phase)
@@ -21,6 +22,8 @@ const open = reactive({
   market: false, gate: false, animals: false, plants: false, assemblies: false
 })
 const bioromeTest = ref(false)
+const theme = themeStore()
+const themeLabel = computed(() => theme.theme === 'light' ? 'Dark Mode' : 'Light Mode')
 // Enable/disable per phase (matrix)
 const allowedSet = computed(() => {
   if (phase.value === 0) {
@@ -76,7 +79,7 @@ onBeforeUnmount(() => {
 import { mapStore } from '@/stores/map.js'
 import { makeInstance } from '@/engine/phases/optimizations/biotaFactories.js'
 import { measureTileProperty } from '@/utils/tileHelpers.js'
-import {makeAssembly} from "@/engine/phases/operations/assemblyFactory.js";
+import {makeAssembly} from '@/engine/phases/operations/assemblyFactory.js';
 
 const map = mapStore()
 
@@ -193,6 +196,7 @@ onBeforeUnmount(stopTestingSync)
                     @click.stop="bioromeTest = !bioromeTest">
               Testing Mode
             </button>
+            <button role="menuitem" @click.stop="theme.toggle()">{{ themeLabel }}</button>
           </div>
         </div>
       </div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,11 +1,14 @@
 import './assets/main.css'
 import { createApp } from 'vue'
-import {createPinia} from 'pinia'
+import { createPinia } from 'pinia'
 import App from './App.vue'
 
+const storedTheme = localStorage.getItem('theme') || 'dark'
+document.documentElement.dataset.theme = storedTheme
 
 const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
 app.mount('#app')
+

--- a/src/stores/theme.js
+++ b/src/stores/theme.js
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+
+export const themeStore = defineStore('theme', () => {
+  const theme = ref(localStorage.getItem('theme') || 'dark')
+
+  document.documentElement.dataset.theme = theme.value
+
+  watch(theme, (val) => {
+    document.documentElement.dataset.theme = val
+    localStorage.setItem('theme', val)
+  }, { immediate: true })
+
+  function toggle () {
+    theme.value = theme.value === 'light' ? 'dark' : 'light'
+  }
+
+  return { theme, toggle }
+})
+


### PR DESCRIPTION
## Summary
- add light and dark color palettes with CSS variables
- store and toggle theme selection with persistence
- expose theme switch in controls menu

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fe84ff1483279c66ad5659cfe66d