### PR TITLE
refactor: centralize metrics table styles and shadows

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -65,6 +65,12 @@ html, body, #app {
   --color-pill-border: #2a2a2a;
   --color-border-card: #2c3e50;
   --radius: 7px;
+  --metrics-selected-bg: color-mix(in srgb, var(--color-warning) 25%, transparent);
+  --metrics-delta-bg: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  --shadow-disabled: color-mix(in srgb, var(--color-danger) 35%, transparent);
+  --shadow-warning: color-mix(in srgb, var(--color-warning) 40%, transparent);
+  --shadow-active: color-mix(in srgb, var(--color-highlight) 50%, transparent);
+  --shadow-label: color-mix(in srgb, var(--color-bg) 50%, transparent);
 }
 
 .menu-panel {
@@ -405,4 +411,20 @@ html, body, #app {
   color: var(--color-bg);
   outline: none;
   cursor: not-allowed;
+}
+/* Metrics table styles */
+.metrics-table {
+  border-collapse: collapse;
+  margin: 0;
+}
+.metrics-table th,
+.metrics-table td {
+  border: 1px solid var(--color-success);
+}
+.metrics-table th.selected,
+.metrics-table td.selected {
+  background: var(--metrics-selected-bg);
+}
+.metrics-table tr.delta-changed > td {
+  background: var(--metrics-delta-bg);
 }

--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -483,23 +483,23 @@ onBeforeUnmount(stopTestingSync)
 .controlButton.s-disabled {
   background: var(--color-danger-bg-dark);
   border-color: var(--color-danger-border-dark);
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, .7),
-  0 0 8px 2px rgba(200, 40, 40, .35);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 70%, transparent),
+  0 0 8px 2px var(--shadow-disabled);
   cursor: not-allowed;
 }
 
 .controlButton.s-idle {
   background: var(--color-warning-bg-dark);
   border-color: var(--color-warning-border-dark);
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, .6),
-  0 0 10px 2px rgba(255, 170, 0, .4);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 60%, transparent),
+  0 0 10px 2px var(--shadow-warning);
 }
 
 .controlButton.s-active {
   background: var(--color-success-bg-dark);
   border-color: var(--color-success-border-dark);
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, .6),
-  0 0 14px 4px rgba(80, 255, 120, .5);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 60%, transparent),
+  0 0 14px 4px var(--shadow-active);
 }
 
 /* labels follow state color */
@@ -508,25 +508,25 @@ onBeforeUnmount(stopTestingSync)
   font-family: ui-monospace, Menlo, monospace;
   font-size: 0.8em;
   color: var(--color-label-text);
-  box-shadow: inset 10px 50px rgba(0, 0, 0, 0.5);
+  box-shadow: inset 10px 50px var(--shadow-label);
   border: 2px inset var(--color-bg);
   padding: 0 3px;
 }
 
 .controlButton.s-disabled + .label {
   color: var(--color-label-danger);
-  text-shadow: 0 0 3px rgba(255, 90, 90, .35);
+  text-shadow: 0 0 3px var(--shadow-disabled);
 
 }
 
 .controlButton.s-idle + .label {
   color: var(--color-label-warning);
-  text-shadow: 0 0 3px rgba(255, 200, 90, .35);
+  text-shadow: 0 0 3px var(--shadow-warning);
 }
 
 .controlButton.s-active + .label {
   color: var(--color-highlight);
-  text-shadow: 0 0 3px rgba(100, 255, 140, .35);
+  text-shadow: 0 0 3px var(--shadow-active);
 }
 
 

--- a/src/components/grid/tileInfoBlocks/MetricsTable.vue
+++ b/src/components/grid/tileInfoBlocks/MetricsTable.vue
@@ -95,7 +95,7 @@ function isNonZeroDelta(property) {
   <div class="metrics-table-wrapper">
     <h1>{{ title }}</h1>
 
-    <table>
+    <table class="metrics-table">
       <thead>
       <tr>
         <th>Property</th>
@@ -181,20 +181,3 @@ function isNonZeroDelta(property) {
 </template>
 
 
-<style>
-.metrics-table-wrapper th, .metrics-table-wrapper td {
-  border: 1px solid green;
-  border-collapse: collapse;
-  margin: 0;
-}
-
-.metrics-table-wrapper th.selected,
-.metrics-table-wrapper td.selected {
-  background: rgba(255, 215, 0, 0.25); /* subtle highlight */
-}
-
-.metrics-table-wrapper tr.delta-changed > td {
-  background: rgba(255, 215, 0, 0.18);
-}
-
-</style>

--- a/src/components/overlays/AnalyticsReport.vue
+++ b/src/components/overlays/AnalyticsReport.vue
@@ -251,9 +251,9 @@ const subcomponents = {
   padding: 2px 6px;
   border: 1px solid color-mix(in oklab, var(--panel-edge), var(--accent) 25%);
   border-radius: 6px;
-  background: linear-gradient(180deg, rgba(125,249,255,.08), rgba(125,249,255,.02));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 8%, transparent), color-mix(in srgb, var(--accent) 2%, transparent));
   color: var(--text);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text) 5%, transparent);
 }
 
 /* Utilities */
@@ -290,8 +290,8 @@ const subcomponents = {
   border-radius: 999px;
   text-decoration: none;
   color: var(--text);
-  background: radial-gradient(100% 100% at 50% 0%, rgba(125,249,255,.10) 0, rgba(125,249,255,0) 60%);
-  box-shadow: inset 0 1px 0 rgba(255,255,255,.06);
+  background: radial-gradient(100% 100% at 50% 0%, color-mix(in srgb, var(--accent) 10%, transparent) 0, transparent 60%);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--text) 6%, transparent);
   line-height: 1.2;
 }
 
@@ -314,7 +314,7 @@ const subcomponents = {
   position: absolute; inset: 0;
   pointer-events: none;
   background:
-      repeating-linear-gradient(0deg, transparent 0 2px, rgba(255,255,255,.008) 2px 3px);
+      repeating-linear-gradient(0deg, transparent 0 2px, color-mix(in srgb, var(--text) 0.8%, transparent) 2px 3px);
   border-radius: 6px;
 }
 


### PR DESCRIPTION
## Summary
- Centralize metrics table styling with semantic variables and global classes
- Replace rgba() colors in analytics report with palette-based color-mix
- Use shared shadow variables for control states

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*
- `npm run lint` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c7070cd54483279a65366d68d2b79a