### PR TITLE
refactor: streamline color tokens

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,6 +1,6 @@
 
 html, body, #app {
-  background: var(--color-bg);
+  background: var(--color-background);
 }
 
 #app {
@@ -10,73 +10,28 @@ html, body, #app {
 }
 
 :root {
-  --color-bg: #000;
+  --color-background: #000;
+  --color-surface: #2c2c2c;
+  --color-border: #2a3b45;
   --color-text: #fff;
-  --color-primary: #00bcd4;
+  --color-accent: #00bcd4;
   --color-success: #82c91e;
   --color-danger: #c62828;
   --color-warning: #ffd600;
-  --color-accent: #cde4cf;
-  --color-dark: #333;
-  --color-gray-100: #eee;
-  --color-gray-200: #ddd;
-  --color-gray-300: #bbb;
-  --color-gray-400: #aaa;
-  --color-gray-500: #888;
-  --color-gray-600: #37474f;
-  --color-gray-700: #263238;
-  --color-gray-800: #222;
-  --color-gray-900: #2c2c2c;
-  --color-panel-border: #2a3b45;
-  --color-text-dim: #a9b4bd;
-  --color-heading: #3d4853;
-  --color-primary-light: #80deea;
-  --color-primary-light2: #b2ebf2;
-  --color-primary-light3: #e0f2fe;
-  --color-primary-dark: #01579b;
-  --color-action-bg: #f9fafb;
-  --color-border-light: #e3e8ee;
-  --color-border-hover: #b0bec5;
-  --color-panel-text: #e0e0e0;
-  --color-warning-dark: #ffb300;
-  --color-success-light: #c8e6c9;
-  --color-success-lighter: #a5d6a7;
-  --color-success-text: #388e3c;
-  --color-success-darker: #1b5e20;
-  --color-projected: #7a5cff;
-  --color-control-border: #2a2f2a;
-  --color-subpanel-border: #1f231f;
-  --color-options-bg: #1a1f1a;
   --color-highlight: #97ffb0;
-  --color-button-border-dark: #202420;
-  --color-button-bg-dark: #0a0d0a;
-  --color-danger-bg-dark: #7b1e1e;
-  --color-danger-border-dark: #612525;
-  --color-warning-bg-dark: #7a5702;
-  --color-warning-border-dark: #6e5a2c;
-  --color-success-bg-dark: #0f7a39;
-  --color-success-border-dark: #1d6f3c;
-  --color-label-text: #cfd3cf;
-  --color-label-danger: #ff8c8c;
-  --color-label-warning: #ffd27a;
-  --color-screen-text: #32cd32;
-  --color-silver: #c0c0c0;
-  --color-grey: #808080;
-  --color-pill-border: #2a2a2a;
-  --color-border-card: #2c3e50;
   --radius: 7px;
   --metrics-selected-bg: color-mix(in srgb, var(--color-warning) 25%, transparent);
   --metrics-delta-bg: color-mix(in srgb, var(--color-warning) 18%, transparent);
   --shadow-disabled: color-mix(in srgb, var(--color-danger) 35%, transparent);
   --shadow-warning: color-mix(in srgb, var(--color-warning) 40%, transparent);
   --shadow-active: color-mix(in srgb, var(--color-highlight) 50%, transparent);
-  --shadow-label: color-mix(in srgb, var(--color-bg) 50%, transparent);
+  --shadow-label: color-mix(in srgb, var(--color-background) 50%, transparent);
 }
 
 .menu-panel {
   border: 2px solid var(--color-accent);
   border-radius: 10px;
-  background: color-mix(in srgb, var(--color-primary), var(--color-text) 80%);
+  background: color-mix(in srgb, var(--color-accent), var(--color-text) 80%);
   padding: 1rem 0.5rem;
   display: flex;
   flex-direction: column;
@@ -93,9 +48,9 @@ html, body, #app {
 
 /* Overlay panel styles */
 .panel {
-  background: color-mix(in srgb, var(--color-bg), var(--color-text) 8%);
-  color: color-mix(in srgb, var(--color-text), var(--color-bg) 12%);
-  border: 1px solid var(--color-primary);
+  background: color-mix(in srgb, var(--color-background), var(--color-text) 8%);
+  color: color-mix(in srgb, var(--color-text), var(--color-background) 12%);
+  border: 1px solid var(--color-accent);
   border-radius: 10px;
   padding: 0.8rem;
   margin: 0;
@@ -157,25 +112,25 @@ html, body, #app {
   justify-content: center;
   align-items: center;
   font-weight: bold;
-  border-top: 1px solid var(--color-primary);
+  border-top: 1px solid var(--color-accent);
   padding: 4px;
 }
 
 /* Key-value table styles */
-.kv {
-  width: 100%;
-  border-collapse: collapse;
-  table-layout: fixed;
-  font-size: 12.5px;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-text) 2%, transparent), color-mix(in srgb, var(--color-bg) 20%, transparent));
-  border: 1px solid var(--color-panel-border);
-  margin: 8px 0;
-  color: var(--color-panel-text);
-}
+  .kv {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+    font-size: 12.5px;
+    background: linear-gradient(180deg, color-mix(in srgb, var(--color-text) 2%, transparent), color-mix(in srgb, var(--color-background) 20%, transparent));
+    border: 1px solid var(--color-border);
+    margin: 8px 0;
+    color: color-mix(in srgb, var(--color-text) 80%, var(--color-background));
+  }
 
 .kv th,
 .kv td {
-  border: 1px solid color-mix(in oklab, var(--color-panel-border), var(--color-bg) 25%);
+    border: 1px solid color-mix(in oklab, var(--color-border), var(--color-background) 25%);
   padding: 6px 8px;
   white-space: nowrap;
   text-align: left;
@@ -199,22 +154,22 @@ html, body, #app {
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: .06em;
-  color: var(--color-text-dim);
-  background: linear-gradient(180deg, color-mix(in srgb, var(--color-bg), var(--color-text) 10%), color-mix(in srgb, var(--color-bg), var(--color-text) 5%));
+    color: color-mix(in srgb, var(--color-text) 70%, var(--color-background));
+  background: linear-gradient(180deg, color-mix(in srgb, var(--color-background), var(--color-text) 10%), color-mix(in srgb, var(--color-background), var(--color-text) 5%));
   position: sticky;
   top: 0;
   z-index: 1;
 }
 
 .kv tbody tr:nth-child(odd) td { background-color: rgba(255,255,255,.015); }
-.kv tbody tr:hover td { background-color: color-mix(in oklab, var(--color-primary), transparent 95%); }
+.kv tbody tr:hover td { background-color: color-mix(in oklab, var(--color-accent), transparent 95%); }
 
 .kv.inner { border: 0; background: transparent; }
 .kv.inner td { border: 0; padding: 2px 0; }
 .kv.inner.onecol td { white-space: normal; }
 
 .operations {
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 .analytics {
@@ -241,28 +196,28 @@ html, body, #app {
 }
 
 .btn--buy {
-  background: var(--color-accent);
-  color: var(--color-dark);
+  background: var(--color-highlight);
+  color: var(--color-background);
 }
 .btn--buy:hover {
-  background: var(--color-primary);
+  background: var(--color-accent);
   color: var(--color-text);
 }
 .btn--buy:disabled {
-  background: var(--color-gray-200);
-  color: var(--color-gray-500);
+  background: color-mix(in srgb, var(--color-text) 80%, var(--color-background));
+  color: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
   cursor: not-allowed;
-  border: 1px solid var(--color-gray-300);
+  border: 1px solid color-mix(in srgb, var(--color-text) 70%, var(--color-background));
 }
 
 .btn--return {
-  background: var(--color-primary-light);
-  color: var(--color-gray-900);
+  background: color-mix(in srgb, var(--color-accent) 40%, var(--color-text));
+  color: var(--color-surface);
   padding: 0.39em 1.1em;
-  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-bg), transparent 94%);
+  box-shadow: 0 2px 4px color-mix(in srgb, var(--color-background), transparent 94%);
 }
 .btn--return:hover {
-  background: var(--color-primary);
+  background: var(--color-accent);
   color: var(--color-text);
 }
 
@@ -272,8 +227,8 @@ html, body, #app {
   padding: 0.35em 1.2em;
 }
 .btn--new:hover {
-  background: var(--color-warning-dark);
-  color: var(--color-dark);
+  background: color-mix(in srgb, var(--color-warning), var(--color-background) 40%);
+  color: var(--color-background);
 }
 
 
@@ -283,63 +238,63 @@ html, body, #app {
 }
 
 .btn--start:disabled {
-  background: var(--color-gray-500);
+  background: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
   cursor: not-allowed;
 }
 
 .btn--start:hover {
-  background: color-mix(in srgb, var(--color-success), var(--color-bg) 25%);
+  background: color-mix(in srgb, var(--color-success), var(--color-background) 25%);
 }
 
 .btn--close {
   background: none;
-  color: var(--color-gray-400);
+  color: color-mix(in srgb, var(--color-text) 60%, var(--color-background));
 }
 .btn--close:hover {
-  color: var(--color-gray-800);
+  color: var(--color-surface);
 }
 
 .btn--save {
   background: var(--color-warning);
-  color: var(--color-dark);
+  color: var(--color-background);
   padding: 0.58em 1.8em;
 }
 .btn--save:hover {
-  background: var(--color-warning-dark);
+  background: color-mix(in srgb, var(--color-warning), var(--color-background) 40%);
 }
 .btn--save:disabled {
-  background: var(--color-gray-100);
-  color: var(--color-gray-400);
+  background: color-mix(in srgb, var(--color-text) 90%, var(--color-background));
+  color: color-mix(in srgb, var(--color-text) 60%, var(--color-background));
   cursor: not-allowed;
 }
 
 .btn--add {
-  background: var(--color-success-light);
-  color: var(--color-success-text);
+  background: color-mix(in srgb, var(--color-success), var(--color-text) 40%);
+  color: color-mix(in srgb, var(--color-success), var(--color-background) 60%);
   padding: 0.23em 0.85em;
 }
 .btn--add:hover {
-  background: var(--color-success-lighter);
-  color: var(--color-success-darker);
+  background: color-mix(in srgb, var(--color-success), var(--color-text) 20%);
+  color: color-mix(in srgb, var(--color-success), var(--color-background) 40%);
 }
 .btn--add:disabled {
-  background: var(--color-gray-100);
-  color: var(--color-gray-400);
+  background: color-mix(in srgb, var(--color-text) 90%, var(--color-background));
+  color: color-mix(in srgb, var(--color-text) 60%, var(--color-background));
   cursor: not-allowed;
 }
 
 .btn--sell {
-  background: var(--color-panel-text);
-  color: var(--color-gray-600);
+  background: color-mix(in srgb, var(--color-text) 80%, var(--color-background));
+  color: color-mix(in srgb, var(--color-text) 40%, var(--color-background));
   padding: 0.23em 0.85em;
 }
 .btn--sell:hover {
-  background: color-mix(in srgb, var(--color-panel-text), var(--color-bg) 10%);
-  color: var(--color-gray-700);
+  background: color-mix(in srgb, var(--color-text) 70%, var(--color-background) 30%);
+  color: color-mix(in srgb, var(--color-text) 30%, var(--color-background));
 }
 .btn--sell:disabled {
-  background: var(--color-gray-100);
-  color: var(--color-gray-400);
+  background: color-mix(in srgb, var(--color-text) 90%, var(--color-background));
+  color: color-mix(in srgb, var(--color-text) 60%, var(--color-background));
   cursor: not-allowed;
 }
 
@@ -352,12 +307,12 @@ html, body, #app {
   margin: 0.25em 0 0;
 }
 .action-area {
-  background: var(--color-action-bg);
+  background: color-mix(in srgb, var(--color-text) 5%, var(--color-background));
   border-radius: 12px;
   box-shadow: 0 1px 8px rgba(120, 140, 180, 0.06);
   margin-bottom: 1.25em;
   padding: 1.15em 1.4em 1.1em 1.4em;
-  border: 1px solid var(--color-border-light);
+  border: 1px solid color-mix(in srgb, var(--color-border), var(--color-text) 80%);
   transition: box-shadow 0.2s;
   position: relative;
 }
@@ -368,7 +323,7 @@ html, body, #app {
 
 .action-area:hover, .action-area:focus-within {
   box-shadow: 0 3px 14px rgba(60, 105, 170, 0.08);
-  border-color: var(--color-border-hover);
+  border-color: color-mix(in srgb, var(--color-border), var(--color-text) 60%);
 }
 
 .action-area h4, .action-area h5 {
@@ -376,13 +331,15 @@ html, body, #app {
   margin-bottom: 0.6em;
   font-size: 1.17em;
   font-weight: 600;
-  color: var(--color-heading);
+  color: color-mix(in srgb, var(--color-text) 70%, var(--color-background));
   letter-spacing: 0.01em;
 }
 
 .action-area button {
-  background: linear-gradient(90deg, var(--color-primary-light3) 0%, var(--color-primary-light2) 100%);
-  color: var(--color-gray-600);
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--color-accent) 10%, var(--color-text) 90%) 0%,
+    color-mix(in srgb, var(--color-accent) 25%, var(--color-text) 75%) 100%);
+  color: color-mix(in srgb, var(--color-text) 40%, var(--color-background));
   border: none;
   border-radius: 7px;
   padding: 0.36em 1.2em;
@@ -400,15 +357,17 @@ html, body, #app {
 }
 
 .action-area button:hover, .action-area button:focus {
-  background: linear-gradient(90deg, var(--color-primary-light2) 0%, var(--color-primary-light) 100%);
-  color: var(--color-primary-dark);
+  background: linear-gradient(90deg,
+    color-mix(in srgb, var(--color-accent) 25%, var(--color-text) 75%) 0%,
+    color-mix(in srgb, var(--color-accent) 40%, var(--color-text) 60%) 100%);
+  color: color-mix(in srgb, var(--color-accent) 60%, var(--color-background));
   box-shadow: 0 3px 7px rgba(30,130,200,0.07);
   outline: none;
 }
 
 .action-area button:disabled {
-  background: var(--color-gray-500);
-  color: var(--color-bg);
+  background: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
+  color: var(--color-background);
   outline: none;
   cursor: not-allowed;
 }

--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -371,8 +371,8 @@ onBeforeUnmount(stopTestingSync)
   gap: 12px;
   padding: 6px 10px;
   height: 10vh;
-  border-bottom: 2px solid var(--color-control-border);
-  background-color: var(--color-grey);
+  border-bottom: 2px solid var(--color-border);
+  background-color: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
 }
 
 /* columns */
@@ -401,7 +401,7 @@ onBeforeUnmount(stopTestingSync)
   gap: 6px;
   height: 8vh;
   padding: 6px 10px;
-  border: 2px solid var(--color-subpanel-border);
+  border: 2px solid var(--color-border);
   border-radius: 8px;
   /*background-image: url("@/assets/steel_plate.png");
   background-size: cover;
@@ -415,7 +415,7 @@ onBeforeUnmount(stopTestingSync)
   text-align: center;
   font-weight: bold;
   pointer-events: none;
-  color: var(--color-bg);
+  color: var(--color-background);
   padding: 0;
   margin: 0;
 }
@@ -428,7 +428,7 @@ onBeforeUnmount(stopTestingSync)
   align-self: center;
   height: 80%;
   margin: 0 10px;
-  background: var(--color-bg);
+  background: var(--color-background);
   border-radius: 2px;
 }
 
@@ -445,8 +445,8 @@ onBeforeUnmount(stopTestingSync)
   height: 12vh;
   width: 100px;
   display: none;
-  background: var(--color-options-bg);
-  border: 1px solid var(--color-control-border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 6px;
 }
@@ -472,8 +472,8 @@ onBeforeUnmount(stopTestingSync)
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  border: 2px solid var(--color-button-border-dark);
-  background: var(--color-button-bg-dark);
+  border: 2px solid var(--color-border);
+  background: var(--color-surface);
   position: relative;
   cursor: pointer;
   transition: transform .05s ease, filter .12s ease;
@@ -481,24 +481,24 @@ onBeforeUnmount(stopTestingSync)
 
 /* states */
 .controlButton.s-disabled {
-  background: var(--color-danger-bg-dark);
-  border-color: var(--color-danger-border-dark);
-  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 70%, transparent),
+  background: color-mix(in srgb, var(--color-danger), var(--color-background) 40%);
+  border-color: color-mix(in srgb, var(--color-danger), var(--color-border) 50%);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-background) 70%, transparent),
   0 0 8px 2px var(--shadow-disabled);
   cursor: not-allowed;
 }
 
 .controlButton.s-idle {
-  background: var(--color-warning-bg-dark);
-  border-color: var(--color-warning-border-dark);
-  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 60%, transparent),
+  background: color-mix(in srgb, var(--color-warning), var(--color-background) 40%);
+  border-color: color-mix(in srgb, var(--color-warning), var(--color-border) 50%);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-background) 60%, transparent),
   0 0 10px 2px var(--shadow-warning);
 }
 
 .controlButton.s-active {
-  background: var(--color-success-bg-dark);
-  border-color: var(--color-success-border-dark);
-  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-bg) 60%, transparent),
+  background: color-mix(in srgb, var(--color-success), var(--color-background) 40%);
+  border-color: color-mix(in srgb, var(--color-success), var(--color-border) 50%);
+  box-shadow: inset 0 2px 6px color-mix(in srgb, var(--color-background) 60%, transparent),
   0 0 14px 4px var(--shadow-active);
 }
 
@@ -507,20 +507,20 @@ onBeforeUnmount(stopTestingSync)
   margin-top: 4px;
   font-family: ui-monospace, Menlo, monospace;
   font-size: 0.8em;
-  color: var(--color-label-text);
+  color: color-mix(in srgb, var(--color-text) 80%, var(--color-background));
   box-shadow: inset 10px 50px var(--shadow-label);
-  border: 2px inset var(--color-bg);
+  border: 2px inset var(--color-background);
   padding: 0 3px;
 }
 
 .controlButton.s-disabled + .label {
-  color: var(--color-label-danger);
+  color: var(--color-danger);
   text-shadow: 0 0 3px var(--shadow-disabled);
 
 }
 
 .controlButton.s-idle + .label {
-  color: var(--color-label-warning);
+  color: var(--color-warning);
   text-shadow: 0 0 3px var(--shadow-warning);
 }
 
@@ -531,15 +531,15 @@ onBeforeUnmount(stopTestingSync)
 
 
 .infoScreen {
-  background-color: var(--color-bg);
+  background-color: var(--color-background);
   position: relative;
   padding: 5px;
-  border: 5px inset var(--color-bg);
+  border: 5px inset var(--color-background);
   height: 75%;
   width: 5vw;
   text-align: left;
   font-size: medium;
-  color: var(--color-screen-text);
+  color: var(--color-success);
   aspect-ratio: 4/3;
   line-height: 1.25rem;
   word-break: break-word;
@@ -549,10 +549,10 @@ onBeforeUnmount(stopTestingSync)
   border-radius: 100%;
   height: 7vh;
   width: 7vh;
-  color: var(--color-bg);
+  color: var(--color-background);
   font-weight: lighter;
   text-shadow: 0 0 5px var(--color-text);
-  background-color: var(--color-silver);
+  background-color: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
 }
 
 .nextPhaseBg {
@@ -578,7 +578,7 @@ onBeforeUnmount(stopTestingSync)
   height: 5vh;
   width: 5vh;
   margin: 0;
-  background: color-mix(in srgb, var(--color-bg) 75%, transparent);
+  background: color-mix(in srgb, var(--color-background) 75%, transparent);
   color: var(--color-text);
 }
 
@@ -587,7 +587,7 @@ onBeforeUnmount(stopTestingSync)
   z-index: 2;
   display: flex;
   gap: 6px;
-  color: var(--color-screen-text);
+  color: var(--color-success);
   margin-bottom: 10px;
   justify-content: space-evenly;
   width: 10vw;
@@ -595,15 +595,15 @@ onBeforeUnmount(stopTestingSync)
 
 .layout-btn {
   display: flex;
-  background: var(--color-silver);
-  border: 2px outset var(--color-bg);
+  background: color-mix(in srgb, var(--color-text) 50%, var(--color-background));
+  border: 2px outset var(--color-background);
   cursor: pointer;
   padding: 3px;
   font-family: monospace;
 }
 
 .layout-btn svg {
-  color: var(--color-bg);
+  color: var(--color-background);
 }
 
 

--- a/src/components/grid/TilesGrid.vue
+++ b/src/components/grid/TilesGrid.vue
@@ -209,8 +209,8 @@ function fmt(v) {
   display: flex;
   user-select: none;
   cursor: pointer;
-  box-shadow: inset 0 0 0 1px var(--color-bg);
-  color: var(--color-bg);
+  box-shadow: inset 0 0 0 1px var(--color-background);
+  color: var(--color-background);
   align-items: center;
   justify-content: center;
   overflow: hidden;
@@ -218,7 +218,7 @@ function fmt(v) {
 .cell.active { outline: 3px solid var(--color-warning); outline-offset: -2px; }
 .cell .cellId { align-self: flex-end; margin: 5px; }
 .cell.unsurveyed .cellId { color: var(--color-text); }
-.cell.unsurveyed { background: color-mix(in srgb, var(--color-bg) 95%, transparent); }
+.cell.unsurveyed { background: color-mix(in srgb, var(--color-background) 95%, transparent); }
 
 .icons {
   position: absolute;
@@ -254,8 +254,8 @@ function fmt(v) {
   gap: .35em;
   font-variant-numeric: tabular-nums;
 }
-.row-res .val.real { color: var(--color-bg); }
-.row-res .val.proj { color: var(--color-projected); } /* optimized text */
+.row-res .val.real { color: var(--color-background); }
+.row-res .val.proj { color: var(--color-accent); } /* optimized text */
 .row-res .proj .icon-img { opacity: .7; filter: hue-rotate(270deg) saturate(1.2); }
 .row-res .both .icon-img { opacity: 1; }
 .row-res .sep { opacity: .7; padding: 0 .1em; }

--- a/src/components/grid/tileInfoBlocks/AssemblyTable.vue
+++ b/src/components/grid/tileInfoBlocks/AssemblyTable.vue
@@ -88,7 +88,7 @@ const optimized = computed(() => Array.isArray(props.tile?.assemblies?.optimized
 }
 .pill {
   padding: 2px 8px;
-  border: 1px solid var(--color-pill-border);
+  border: 1px solid var(--color-border);
   border-radius: 999px;
   font-size: 12px;
   line-height: 1.6;

--- a/src/components/grid/tileInfoBlocks/BiotaTable.vue
+++ b/src/components/grid/tileInfoBlocks/BiotaTable.vue
@@ -195,7 +195,7 @@ td.entity-cell { vertical-align: top; }
   margin-top: 4px;
 }
 
-.badge { display: inline-flex; align-items: center; gap: .35em; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); font-size: .85em; background: color-mix(in srgb, var(--color-bg) 18%, transparent); }
-.badge--real { color: var(--ink); background: color-mix(in srgb, var(--color-bg) 8%, transparent); }
-.badge--proj { color: var(--color-text); background: color-mix(in srgb, var(--color-projected) 22%, transparent); border-color: color-mix(in srgb, var(--color-projected) 65%, transparent); }
+.badge { display: inline-flex; align-items: center; gap: .35em; padding: 2px 8px; border-radius: 999px; border: 1px solid var(--border); font-size: .85em; background: color-mix(in srgb, var(--color-background) 18%, transparent); }
+.badge--real { color: var(--ink); background: color-mix(in srgb, var(--color-background) 8%, transparent); }
+.badge--proj { color: var(--color-text); background: color-mix(in srgb, var(--color-accent) 22%, transparent); border-color: color-mix(in srgb, var(--color-accent) 65%, transparent); }
 </style>

--- a/src/components/overlays/AnalyticsReport.vue
+++ b/src/components/overlays/AnalyticsReport.vue
@@ -161,16 +161,16 @@ const subcomponents = {
 <style scoped>
 /* ---------- Theme tokens (fallbacks if global vars aren’t present) ---------- */
 .analyticsReport {
-  --panel-bg:       var(--ui-bg, var(--color-bg));
-  --panel-elev:     var(--ui-elev, color-mix(in srgb, var(--color-bg), var(--color-text) 5%));
-  --panel-edge:     var(--ui-edge, var(--color-panel-border));
+  --panel-bg:       var(--ui-bg, var(--color-background));
+  --panel-elev:     var(--ui-elev, color-mix(in srgb, var(--color-background), var(--color-text) 5%));
+  --panel-edge:     var(--ui-edge, var(--color-border));
   --panel-stripe:   var(--ui-stripe, color-mix(in srgb, var(--color-text) 3%, transparent));
   --text:           var(--ui-text, var(--color-text));
-  --text-dim:       var(--ui-text-dim, var(--color-text-dim));
-  --accent:         var(--ui-accent, var(--color-primary));
-  --accent-dim:     color-mix(in oklab, var(--accent), var(--color-bg) 40%);
-  --shadow-inset:   inset 0 1px 0 color-mix(in srgb, var(--color-text) 4%, transparent), inset 0 -1px 0 color-mix(in srgb, var(--color-bg) 40%, transparent);
-  --shadow-raised:  0 1px 1px color-mix(in srgb, var(--color-bg) 35%, transparent), 0 8px 24px color-mix(in srgb, var(--color-bg) 35%, transparent);
+  --text-dim:       var(--ui-text-dim, color-mix(in srgb, var(--color-text) 70%, var(--color-background)));
+  --accent:         var(--ui-accent, var(--color-accent));
+  --accent-dim:     color-mix(in oklab, var(--accent), var(--color-background) 40%);
+  --shadow-inset:   inset 0 1px 0 color-mix(in srgb, var(--color-text) 4%, transparent), inset 0 -1px 0 color-mix(in srgb, var(--color-background) 40%, transparent);
+  --shadow-raised:  0 1px 1px color-mix(in srgb, var(--color-background) 35%, transparent), 0 8px 24px color-mix(in srgb, var(--color-background) 35%, transparent);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   color: var(--text);
 }
@@ -201,8 +201,8 @@ const subcomponents = {
   letter-spacing: .08em; text-transform: uppercase;
   color: var(--text);
   background:
-      linear-gradient(180deg, color-mix(in srgb, var(--color-text) 6%, transparent), color-mix(in srgb, var(--color-bg) 20%, transparent)),
-      linear-gradient(180deg, color-mix(in srgb, var(--color-bg), var(--color-text) 8%), color-mix(in srgb, var(--color-bg), var(--color-text) 4%));
+      linear-gradient(180deg, color-mix(in srgb, var(--color-text) 6%, transparent), color-mix(in srgb, var(--color-background) 20%, transparent)),
+      linear-gradient(180deg, color-mix(in srgb, var(--color-background), var(--color-text) 8%), color-mix(in srgb, var(--color-background), var(--color-text) 4%));
   border-bottom: 1px solid var(--panel-edge);
   cursor: pointer;
   user-select: none;
@@ -273,8 +273,8 @@ const subcomponents = {
   border: 1px solid var(--panel-edge);
   border-radius: 6px;
   background:
-      linear-gradient(180deg, color-mix(in srgb, var(--color-text) 3%, transparent), color-mix(in srgb, var(--color-bg) 18%, transparent)),
-      linear-gradient(180deg, color-mix(in srgb, var(--color-bg), var(--color-text) 10%), color-mix(in srgb, var(--color-bg), var(--color-text) 5%));
+      linear-gradient(180deg, color-mix(in srgb, var(--color-text) 3%, transparent), color-mix(in srgb, var(--color-background) 18%, transparent)),
+      linear-gradient(180deg, color-mix(in srgb, var(--color-background), var(--color-text) 10%), color-mix(in srgb, var(--color-background), var(--color-text) 5%));
   box-shadow: var(--shadow-inset);
 }
 :deep(.table-header > strong) {

--- a/src/components/overlays/AnimalsMenu.vue
+++ b/src/components/overlays/AnimalsMenu.vue
@@ -98,13 +98,13 @@ function addAnimalToTile(animalType, growthStage) {
 }
 
 .card {
-  border: 1px solid var(--color-border-card);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: color-mix(in srgb, var(--color-bg) 25%, transparent);
+  background: color-mix(in srgb, var(--color-background) 25%, transparent);
 }
 
 .card-header {
@@ -133,7 +133,7 @@ function addAnimalToTile(animalType, growthStage) {
   width: 100%;
   padding: 8px 10px;
   border-radius: 8px;
-  border: 1px solid var(--color-border-card);
+  border: 1px solid var(--color-border);
   background: transparent;
   cursor: pointer;
   color: var(--color-text);

--- a/src/components/overlays/AssembliesMenu.vue
+++ b/src/components/overlays/AssembliesMenu.vue
@@ -101,13 +101,13 @@ function addActionToTile(category, action) {
 }
 
 .card {
-  border: 1px solid var(--color-border-card);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: color-mix(in srgb, var(--color-bg) 25%, transparent);
+  background: color-mix(in srgb, var(--color-background) 25%, transparent);
 }
 
 .card-header {

--- a/src/components/overlays/Market.vue
+++ b/src/components/overlays/Market.vue
@@ -206,7 +206,7 @@ const animalsRows = computed(() => {
 
 h3 {
   margin: .2rem 0 .4rem;
-  color: var(--color-primary);
+  color: var(--color-accent);
 }
 
 h4 {

--- a/src/components/overlays/PlantsMenu.vue
+++ b/src/components/overlays/PlantsMenu.vue
@@ -103,13 +103,13 @@ function plantStagePrice(plant, growthStage) {
 }
 
 .card {
-  border: 1px solid var(--color-border-card);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 8px;
-  background: color-mix(in srgb, var(--color-bg) 25%, transparent);
+  background: color-mix(in srgb, var(--color-background) 25%, transparent);
 }
 
 .card-header {
@@ -126,7 +126,7 @@ function plantStagePrice(plant, growthStage) {
 .phase-button {
   display: flex; align-items: center; justify-content: space-between;
   width: 100%; padding: 8px 10px; border-radius: 8px;
-  border: 1px solid var(--color-border-card);
+  border: 1px solid var(--color-border);
   background: transparent; cursor: pointer; color: var(--color-text);
 }
 .phase-button:disabled { opacity: 0.5; cursor: not-allowed; }


### PR DESCRIPTION
## Summary
- consolidate CSS variables into semantic color tokens
- update components to use the new tokens
- remove duplicate grey variables

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c709a11a988327892aac803068439d