### PR TITLE
feat: add theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="">
+<html lang="" data-theme="dark">
   <head>
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -9,13 +9,40 @@ html, body, #app {
   color: var(--color-text);
 }
 
-:root {
+
+:root[data-theme="dark"] {
   --color-background: #000;
   --color-surface: #2c2c2c;
   --color-border: #2a3b45;
   --color-text: #fff;
   --color-accent: #00bcd4;
   --color-success: #82c91e;
+  --color-danger: #c62828;
+  --color-warning: #ffd600;
+  --color-highlight: #97ffb0;
+  --radius: 7px;
+  --metrics-selected-bg: color-mix(in srgb, var(--color-warning) 25%, transparent);
+  --metrics-delta-bg: color-mix(in srgb, var(--color-warning) 18%, transparent);
+  --shadow-disabled: color-mix(in srgb, var(--color-danger) 35%, transparent);
+  --shadow-warning: color-mix(in srgb, var(--color-warning) 40%, transparent);
+  --shadow-active: color-mix(in srgb, var(--color-highlight) 50%, transparent);
+  --shadow-label: color-mix(in srgb, var(--color-background) 50%, transparent);
+  --color-table-stripe: color-mix(in srgb, var(--color-text) 1.5%, transparent);
+  --color-shadow-neutral: color-mix(in srgb, var(--color-border) 50%, var(--color-text) 50%);
+  --color-shadow-accent: color-mix(in srgb, var(--color-accent) 60%, var(--color-text) 40%);
+  --shadow-action-area: 0 1px 8px color-mix(in srgb, var(--color-shadow-neutral) 6%, transparent);
+  --shadow-action-area-hover: 0 3px 14px color-mix(in srgb, var(--color-shadow-accent) 8%, transparent);
+  --shadow-action-button: 0 1px 3px color-mix(in srgb, var(--color-shadow-neutral) 6%, transparent);
+  --shadow-action-button-hover: 0 3px 7px color-mix(in srgb, var(--color-shadow-accent) 7%, transparent);
+}
+
+:root[data-theme="light"] {
+  --color-background: #fff;
+  --color-surface: #f5f5f5;
+  --color-border: #cfd8dc;
+  --color-text: #000;
+  --color-accent: #00bcd4;
+  --color-success: #4caf50;
   --color-danger: #c62828;
   --color-warning: #ffd600;
   --color-highlight: #97ffb0;

--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -4,7 +4,6 @@ import eventBus from '@/eventBus.js'
 import {gameStore} from '@/stores/game.js'
 import {clearSavedStores, loadAllStores} from '@/utils/persistance.js'
 import { formatDateLocale, formatDateTime } from '@/utils/formatting.js'
-
 const game = gameStore()
 const phase = computed(() => game.phase)
 const currentPhaseLabel = computed(() => game.engines[(phase.value) % game.engines.length])
@@ -21,6 +20,14 @@ const open = reactive({
   market: false, gate: false, animals: false, plants: false, assemblies: false
 })
 const bioromeTest = ref(false)
+
+function toggleTheme() {
+  game.currentTheme = game.currentTheme === 'dark' ? 'light' : 'dark'
+}
+
+watch(() => game.currentTheme, (val) => {
+  document.documentElement.dataset.theme = val
+}, { immediate: true })
 // Enable/disable per phase (matrix)
 const allowedSet = computed(() => {
   if (phase.value === 0) {
@@ -192,6 +199,11 @@ onBeforeUnmount(stopTestingSync)
                     :class="{ active: bioromeTest }"
                     @click.stop="bioromeTest = !bioromeTest">
               Testing Mode
+            </button>
+            <button role="menuitem"
+                    :class="{ active: game.currentTheme === 'light' }"
+                    @click.stop="toggleTheme">
+              Light Theme
             </button>
           </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -2,10 +2,12 @@ import './assets/main.css'
 import { createApp } from 'vue'
 import {createPinia} from 'pinia'
 import App from './App.vue'
+import { gameStore } from './stores/game.js'
 
 
 const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
+gameStore()
 app.mount('#app')

--- a/src/stores/game.js
+++ b/src/stores/game.js
@@ -1,5 +1,5 @@
 import {defineStore} from 'pinia'
-import {computed, ref, watch} from 'vue'
+import {computed, ref} from 'vue'
 import { formatDate } from '@/utils/formatting.js'
 
 export const gameStore = defineStore('gameStore', () => {
@@ -51,6 +51,7 @@ export const gameStore = defineStore('gameStore', () => {
     const userAvatar = ref('')
 
     const difficulty = ref(1)
+    const currentTheme = ref('dark')
 
     return {
         gold,
@@ -62,6 +63,7 @@ export const gameStore = defineStore('gameStore', () => {
         userName,
         userAvatar,
         difficulty,
+        currentTheme,
         bioromizationStage,
         bioromizationStages,
         phase,


### PR DESCRIPTION
## Summary
- define light and dark CSS palettes using data-theme selectors
- keep current theme in game store and sync it with document dataset
- expose toggle in Controls options menu and initialize theme on app start

## Testing
- `npm run lint`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d78da8208327a639e9e0dbe126c4