### PR TITLE
refactor: promote market screen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,6 +6,7 @@ import StartingScreen from '/src/components/StartingScreen.vue'
 import {onBeforeUnmount, onMounted, ref} from 'vue'
 import Map from '/src/components/Map.vue';
 import AssemblyAssemblyAssembly from '@/components/AssemblyStation.vue';
+import Market from '/src/components/Market.vue';
 
 
 
@@ -41,10 +42,11 @@ onBeforeUnmount(() => {
 <template>
   <main>
     <StartingScreen v-if="currentArea === 'start'"/>
-    <Map v-if="currentArea === 'map'"/>
-    <AssemblyAssemblyAssembly v-if="currentArea=== 'assembly'"/>
-  </main>
-</template>
+      <Map v-if="currentArea === 'map'"/>
+      <AssemblyAssemblyAssembly v-if="currentArea=== 'assembly'"/>
+      <Market v-if="currentArea === 'market'"/>
+    </main>
+  </template>
 
 <style>
 html, body, #app {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -14,7 +14,6 @@ import PlantsMenu from '@/components/menus/PlantsMenu.vue'
 import FarmGate from '@/components/menus/FarmGate.vue'
 import TilesGrid from '@/components/grid/TilesGrid.vue'
 import {loadAllStores} from '@/utils/persistance.js'
-import Market from '@/components/menus/Market.vue'
 import News from '@/components/menus/News.vue'
 import {produceReport} from '@/engine/phases/analytics/produceReport.js';
 import updateGame from '@/engine/simulationUpdate/updateGame.js';
@@ -25,7 +24,7 @@ const map = mapStore()
 /* ---------------- Open/close truth per overlay ---------------- */
 const show = ref({
   log: false, analytics: false, animals: false, plants: false, assemblies: false,
-  gate: false, weather: false, resources: false, market: false, news: false
+  gate: false, weather: false, resources: false, news: false
 })
 
 /* ---------------- Lane manager (placement + order) ---------------- */
@@ -41,7 +40,6 @@ const compByKey = {
   weather: WeatherPanel,
   log: EventLog,
   analytics: AnalyticsReport,
-  market: Market,
   animals: AnimalsMenu,
   plants: PlantsMenu,
   assemblies: AssembliesMenu,
@@ -169,7 +167,6 @@ function handlePhaseChange() {
     off('analytics');
     off('weather');
     off('news');
-    off('market');
     // not allowed
     disable('animals');
     disable('plants');
@@ -192,7 +189,6 @@ function handlePhaseChange() {
     // available but closed
     off('weather');
     off('news');
-    off('market');
     off('analytics');
     off('log')
     // not allowed
@@ -209,7 +205,6 @@ function handlePhaseChange() {
     // available but closed
     off('weather');
     off('news');
-    off('market');
     off('log')
     // not allowed
     disable('animals');

--- a/src/components/Market.vue
+++ b/src/components/Market.vue
@@ -1,6 +1,6 @@
 <script setup>
-//TODO => Move this view into it's own screen like the assemblies station, not as a menu
 import { computed } from 'vue'
+import eventBus from '@/eventBus.js'
 import { gameStore } from '@/stores/game.js'
 import { marketStore } from '@/stores/market.js'
 import simpleTable from '@/components/menus/blocks/SimpleTable.vue'
@@ -72,6 +72,7 @@ const animalsRows = computed(() => {
 
 </script>
 <template>
+  <button @click="eventBus.emit('nav', 'map')">Back to map</button>
   <div class="market-overlay">
     <header class="bar">
       <div><strong>Market</strong></div>

--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -15,10 +15,10 @@ const gold = computed(() => game.gold)
 const stageLabel = computed(() => game.bioromizationStages[game.bioromizationStage] || 'discovery')
 
 // Active highlight per overlay (toggled via existing `overlay` events)
-const open = reactive({
-  weather: false, news: false, log: false, analytics: false,
-  market: false, gate: false, animals: false, plants: false, assemblies: false
-})
+  const open = reactive({
+    weather: false, news: false, log: false, analytics: false,
+    gate: false, animals: false, plants: false, assemblies: false
+  })
 const bioromeTest = ref(false)
 
 function toggleTheme() {
@@ -28,14 +28,14 @@ function toggleTheme() {
 
 // Enable/disable per phase (matrix)
 const allowedSet = computed(() => {
-  if (phase.value === 0) {
-    return new Set(['weather', 'news', 'log', 'analytics', 'market']) // analytics enabled, user may open
-  } else if (phase.value === 1) {
-    return new Set(['weather', 'news', 'log', 'analytics', 'market', 'animals', 'plants', 'assemblies'])
-  } else { // phase 2
-    return new Set(['weather', 'news', 'log', 'market', 'assemblies', 'gate'])
-  }
-})
+    if (phase.value === 0) {
+      return new Set(['weather', 'news', 'log', 'analytics']) // analytics enabled, user may open
+    } else if (phase.value === 1) {
+      return new Set(['weather', 'news', 'log', 'analytics', 'animals', 'plants', 'assemblies'])
+    } else { // phase 2
+      return new Set(['weather', 'news', 'log', 'assemblies', 'gate'])
+    }
+  })
 
 // Keep highlights consistent when phase changes
 watch(allowedSet, (allow) => {
@@ -265,6 +265,9 @@ onBeforeUnmount(stopTestingSync)
       <div class="subpanel">
         <button id="assemblyStation" class="app-button" @click.stop="eventBus.emit('nav', 'assembly')">Assembly Station</button>
       </div>
+      <div class="subpanel">
+        <button id="marketNav" class="app-button" @click.stop="eventBus.emit('nav', 'market')">Market</button>
+      </div>
     </div>
     <div class="centerPanel">
       <div class="subpanel">
@@ -303,15 +306,6 @@ onBeforeUnmount(stopTestingSync)
           </button>
 
           <div class="app-label">Analytics</div>
-        </div>
-        <hr/>
-        <div class="controlItem" v-show="allowedSet.has('market')">
-          <button id="showMarket" class="app-button"
-                  :class="stateClass('market')"
-
-                  @click.stop="eventBus.emit('overlay', { target: 'market' })">
-          </button>
-          <div class="app-label">Market</div>
         </div>
         <div class="controlItem" v-show="allowedSet.has('gate')">
           <button id="showGate" class="app-button"


### PR DESCRIPTION
## Summary
- move Market overlay into standalone screen with back button
- hook Market screen into App navigation
- replace overlay access with navigation button and remove overlay remnants

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8025bad808327ad7c860b81706909