### PR TITLE
Fix central control panel overflow

### DIFF
--- a/src/components/grid/Controls.vue
+++ b/src/components/grid/Controls.vue
@@ -562,10 +562,16 @@ onBeforeUnmount(stopTestingSync)
   flex: 1 1 auto;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   min-width: 0;
   height: 100%;
+}
 
+.centerPanel > .subpanel {
+  flex: 1 1 auto;
+  width: 100%;
+  max-width: none;
+  min-width: 0;
 }
 
 .subpanel {
@@ -620,7 +626,25 @@ onBeforeUnmount(stopTestingSync)
 .subpanel--toggles {
   justify-content: center;
   gap: 16px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-gutter: stable both-edges;
+}
+
+.subpanel--toggles::-webkit-scrollbar {
+  height: 8px;
+}
+
+.subpanel--toggles::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--color-border) 65%, transparent);
+  border-radius: 999px;
+}
+
+.subpanel--toggles::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .subpanel--info {


### PR DESCRIPTION
## Summary
- ensure the centre control panel stretches to the available width so menu buttons stay in view
- enable horizontal scrolling (with custom scrollbar styling) on the menu strip so no toggle can disappear

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8925ed508832799a59286d505ccbd