### PR TITLE
Sync theme with store on app startup

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -9,5 +9,23 @@ const app = createApp(App)
 const pinia = createPinia()
 
 app.use(pinia)
-gameStore()
+
+const game = gameStore()
+const root = document.documentElement
+
+function applyTheme(theme) {
+  const normalized = typeof theme === 'string' ? theme.trim() : ''
+  if (normalized) {
+    root.dataset.theme = normalized
+  } else {
+    delete root.dataset.theme
+  }
+}
+
+applyTheme(game.currentTheme)
+
+game.$subscribe((_, state) => {
+  applyTheme(state.currentTheme)
+})
+
 app.mount('#app')


### PR DESCRIPTION
## Summary
- apply the stored theme to the document root when the app boots
- keep the root data-theme attribute in sync with later theme changes

## Testing
- npm run test *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68c93c3f3920832783b786b3677221a8