### PR TITLE
Add configurable map resolutions

### DIFF
--- a/src/stores/map.js
+++ b/src/stores/map.js
@@ -2,10 +2,13 @@ import { defineStore } from 'pinia';
 import { computed, ref } from 'vue';
 import { gameStore } from '@/stores/game.js';
 
+const TOTAL_AREA_HA = 100;
+const DEFAULT_GRID_SIZE = 10;
+
 export const mapStore = defineStore('mapStore', () => {
   const game = gameStore();
 
-  const size = computed(() => game.size);
+  const size = computed(() => clampGridSize(game.size ?? DEFAULT_GRID_SIZE));
 
   const topographyConstraints = {
     elevationRange: [0, 220],
@@ -13,295 +16,8 @@ export const mapStore = defineStore('mapStore', () => {
     cellSize: 100,
   };
 
-  const tiles = ref(
-    Array.from({ length: size.value }, (_, row) =>
-      Array.from({ length: size.value }, (_, col) => ({
-        row,
-        col,
-        topography: {
-          elevation: {
-            env: 0,
-            unit: 'm',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          slope: {
-            env: 0,
-            unit: 'deg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          aspect: {
-            env: 0,
-            unit: 'deg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          waterTable: {
-            env: 0,
-            unit: 'm',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          drainageIndex: {
-            env: 0,
-            unit: 'index',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-        },
-
-        soil: {
-          // CHEMISTRY
-          ph: {
-            env: 7.0,
-            unit: 'pH',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          ec: {
-            env: 0,
-            unit: 'dS/m',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          salinity: {
-            env: 0,
-            unit: 'dS/m',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          cec: {
-            env: 10,
-            unit: 'cmol(+)/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          organicCarbon: {
-            env: 2.0,
-            unit: '%',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          //Nutrients
-          N: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          }, // nitrate-N
-          NH4: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          }, // ammonium-N
-          P: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          }, // phosphate-P
-          K: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          }, // potassium-K
-          DON: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          }, // dissolved organic N
-          //Heavy metals
-          Cd: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          Pb: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          As: {
-            env: 0,
-            unit: 'mg/kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-
-          // PHYSICS
-          water: {
-            env: 0,
-            unit: 'mm',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          infiltrationRate: {
-            env: 15,
-            unit: 'mm/hr',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          bulkDensity: {
-            env: 1.3,
-            unit: 'g/cm3',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          penetrationResistance: {
-            env: 0.5,
-            unit: 'MPa',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          aggregateStability: {
-            env: 50,
-            unit: '%',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          hydraulicConductivity: {
-            env: 10,
-            unit: 'mm/hr',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          soilTemperature: {
-            env: 15,
-            unit: '°C',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-
-          microbialCFU_good: {
-            env: 0,
-            unit: 'CFU/g',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          microbialCFU_bad: {
-            env: 0,
-            unit: 'CFU/g',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          mycorrhizalColonization: {
-            env: 0,
-            unit: '%',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          earthwormCount: {
-            env: 0,
-            unit: '1/m2',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-        },
-
-        plants: { real: [], optimized: [] },
-        animals: { real: [], optimized: [] },
-        assemblies: { real: [], optimized: [] },
-        resources: {
-          water: {
-            env: 0,
-            unit: 'm3',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          waste: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          electricity: {
-            env: 0,
-            unit: 'kW/h',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          feed: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          fertilizer: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          fertilizer_liquid: {
-            env: 0,
-            unit: 'L',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          compost: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          biochar: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          manure: {
-            env: 0,
-            unit: 'm3',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          harvested_crop: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          animal_products: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          plant_residue: {
-            env: 0,
-            unit: 'kg',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          biogas: {
-            env: 0,
-            unit: 'm3',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          energy_dc_kWh: {
-            env: 0,
-            unit: 'kWh',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-          energy_ac_kWh: {
-            env: 0,
-            unit: 'kWh',
-            measured: { value: null, history: [], date: null, collect: false },
-            optimized: null,
-          },
-        },
-      }))
-    )
-  );
+  const tileAreaHa = ref(calculateTileArea(size.value, TOTAL_AREA_HA));
+  const tiles = ref(createTiles(size.value, tileAreaHa.value));
 
   const gate = ref([]);
   const station = ref([]);
@@ -317,8 +33,17 @@ export const mapStore = defineStore('mapStore', () => {
     weatherHistory: null,
   });
   const weatherHistory = ref([]);
-  //TODO => Implement week long weather forecast by generating 7 days of weather, and then vary the forecast daily to get the real weather.
   const weatherForecast = ref([]);
+
+  function resetTiles(nextSize = size.value) {
+    const normalizedSize = clampGridSize(nextSize ?? size.value);
+    const area = calculateTileArea(normalizedSize, TOTAL_AREA_HA);
+    tiles.value = createTiles(normalizedSize, area);
+    tileAreaHa.value = area;
+    if (game.size !== normalizedSize) {
+      game.size = normalizedSize;
+    }
+  }
 
   return {
     tiles,
@@ -330,5 +55,92 @@ export const mapStore = defineStore('mapStore', () => {
     currentWeather,
     weatherHistory,
     weatherForecast,
+    tileAreaHa,
+    totalAreaHa: TOTAL_AREA_HA,
+    resetTiles,
   };
 });
+
+function clampGridSize(value) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_GRID_SIZE;
+  return Math.max(1, Math.min(20, Math.round(parsed)));
+}
+
+function calculateTileArea(gridSize, totalAreaHa) {
+  const divisor = Math.max(1, gridSize * gridSize);
+  return Math.round((totalAreaHa / divisor) * 100) / 100;
+}
+
+function createTiles(size, tileAreaHa) {
+  return Array.from({ length: size }, (_, row) =>
+    Array.from({ length: size }, (_, col) => ({
+      row,
+      col,
+      areaHa: tileAreaHa,
+      metadata: { surveyed: false },
+      topography: {
+        elevation: createMeasuredField(0, 'm'),
+        slope: createMeasuredField(0, 'deg'),
+        aspect: createMeasuredField(0, 'deg'),
+        waterTable: createMeasuredField(0, 'm'),
+        drainageIndex: createMeasuredField(0, 'index'),
+      },
+      soil: {
+        ph: createMeasuredField(7, 'pH'),
+        ec: createMeasuredField(0, 'dS/m'),
+        salinity: createMeasuredField(0, 'dS/m'),
+        cec: createMeasuredField(10, 'cmol(+)/kg'),
+        organicCarbon: createMeasuredField(2, '%'),
+        N: createMeasuredField(0, 'mg/kg'),
+        NH4: createMeasuredField(0, 'mg/kg'),
+        P: createMeasuredField(0, 'mg/kg'),
+        K: createMeasuredField(0, 'mg/kg'),
+        DON: createMeasuredField(0, 'mg/kg'),
+        Cd: createMeasuredField(0, 'mg/kg'),
+        Pb: createMeasuredField(0, 'mg/kg'),
+        As: createMeasuredField(0, 'mg/kg'),
+        water: createMeasuredField(0, 'mm'),
+        infiltrationRate: createMeasuredField(15, 'mm/hr'),
+        bulkDensity: createMeasuredField(1.3, 'g/cm3'),
+        penetrationResistance: createMeasuredField(0.5, 'MPa'),
+        aggregateStability: createMeasuredField(50, '%'),
+        hydraulicConductivity: createMeasuredField(10, 'mm/hr'),
+        soilTemperature: createMeasuredField(15, '°C'),
+        microbialCFU_good: createMeasuredField(0, 'CFU/g'),
+        microbialCFU_bad: createMeasuredField(0, 'CFU/g'),
+        mycorrhizalColonization: createMeasuredField(0, '%'),
+        earthwormCount: createMeasuredField(0, '1/m2'),
+      },
+      plants: { real: [], optimized: [] },
+      animals: { real: [], optimized: [] },
+      assemblies: { real: [], optimized: [] },
+      resources: {
+        water: createMeasuredField(0, 'm3'),
+        waste: createMeasuredField(0, 'kg'),
+        electricity: createMeasuredField(0, 'kW/h'),
+        feed: createMeasuredField(0, 'kg'),
+        fertilizer: createMeasuredField(0, 'kg'),
+        fertilizer_liquid: createMeasuredField(0, 'L'),
+        compost: createMeasuredField(0, 'kg'),
+        biochar: createMeasuredField(0, 'kg'),
+        manure: createMeasuredField(0, 'm3'),
+        harvested_crop: createMeasuredField(0, 'kg'),
+        animal_products: createMeasuredField(0, 'kg'),
+        plant_residue: createMeasuredField(0, 'kg'),
+        biogas: createMeasuredField(0, 'm3'),
+        energy_dc_kWh: createMeasuredField(0, 'kWh'),
+        energy_ac_kWh: createMeasuredField(0, 'kWh'),
+      },
+    }))
+  );
+}
+
+function createMeasuredField(env = 0, unit = '') {
+  return {
+    env,
+    unit,
+    measured: { value: null, history: [], date: null, collect: false },
+    optimized: null,
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated start screen selector for choosing between 10×10 and 5×5 maps and show the per-tile area
- allow the map store to regenerate its grid based on the chosen resolution and expose tile area metadata for later use

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bb2b4d9248327965e9412a18daac0)